### PR TITLE
Copy from f0cal/core

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # install_requires = numpy; scipy
+install_requires = venusian; pandas;
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/plugnparse/__init__.py
+++ b/src/plugnparse/__init__.py
@@ -1,16 +1,37 @@
 # -*- coding: utf-8 -*-
 
-__author__ = 'Brian Rossa'
-__email__ = 'br@f0cal.com'
-__version__ = '0.0.1'
+__author__ = "Brian Rossa"
+__email__ = "br@f0cal.com"
+__version__ = "0.0.1"
 
 from .decorators import *
 from .parserfactory import ParserFactory
+from .plugins import PluginScanner
 
-def scan_and_run(package_name, base_parser=None):
-    parser = base_parser or __import__('argparse').ArgumentParser()
+
+def scan_and_run(package_name, base_parser=None, use_dict=True, use_kwargs=True):
+    return run(
+        scan(package_name, base_parser), use_dict=use_dict, use_kwargs=use_kwargs
+    )
+    # parser = base_parser or __import__('argparse').ArgumentParser()
+    # factory = ParserFactory(base=parser)
+    # factory.read_package(__import__(package_name))
+    # parser = factory.make_parser()
+    # ns = parser.parse_args()
+    # return ns.func(ns, parser)
+
+
+def scan(package_name, base_parser=None):
+    parser = base_parser or __import__("argparse").ArgumentParser()
     factory = ParserFactory(base=parser)
     factory.read_package(__import__(package_name))
+    return factory
+
+
+def run(factory, use_dict=True, use_kwargs=True):
     parser = factory.make_parser()
-    ns = parser.parse_args()
-    return ns.func(ns, parser)
+    ns, _func = parser.parse_args()
+    ns = vars(ns) if use_dict or use_kwargs else ns
+    if use_kwargs:
+        return _func(parser, **ns)
+    return _func(parser, ns)

--- a/src/plugnparse/decorators.py
+++ b/src/plugnparse/decorators.py
@@ -1,11 +1,26 @@
 import venusian
 
+
 def entrypoint(cmds, args=None):
     if args is None:
         args = lambda _parser: None
+
     def _entrypoint(wrapped):
         def callback(scanner, name, ob):
             scanner.entrypoints.append((cmds, args, ob))
-        venusian.attach(wrapped, callback, category='plugnparse')
+
+        venusian.attach(wrapped, callback, category="plugnparse")
         return wrapped
+
     return _entrypoint
+
+
+def modifier(cmds):
+    def _modifier(wrapped):
+        def callback(scanner, name, ob):
+            scanner.modifiers.append((cmds, ob))
+
+        venusian.attach(wrapped, callback, category="plugnparse")
+        return wrapped
+
+    return _modifier

--- a/src/plugnparse/parserfactory.py
+++ b/src/plugnparse/parserfactory.py
@@ -1,8 +1,10 @@
+import sys
 import argparse
 import venusian
 
+
 class ParserTree(object):
-    _dest_prefix = 'cmd'
+    _dest_prefix = "cmd"
 
     def __init__(self, base=None):
         if base is None:
@@ -13,7 +15,7 @@ class ParserTree(object):
 
     def _make_tuple(self, item):
         if isinstance(item, str):
-            return (item, )
+            return (item,)
         return tuple(item)
 
     def __getitem__(self, item):
@@ -34,12 +36,13 @@ class ParserTree(object):
             _parsers[item] = _subparsers[parent_item].add_parser(item[-1])
         return _parsers[item]
 
+
 class ParserFactory(object):
     def __init__(self, base=None, target=None):
         if base is None:
             base = argparse.ArgumentParser()
         if target is None:
-            target = 'func'
+            target = "func"
         self._tree = ParserTree(base)
         self._captured_parse_args = base.parse_args
         self._captured_parse_known_args = base.parse_known_args
@@ -47,26 +50,58 @@ class ParserFactory(object):
         base.parse_known_args = self._parse_known_args
         self._base = base
         self._target = target
+        self._scanned_list = []
+
+    @property
+    def tree(self):
+        return self._tree
 
     def read_annotated_class(self, cls):
         for attr in dir(cls):
-            if not attr.startswith('cli_'):
+            if not attr.startswith("cli_"):
                 continue
-            cmds = attr.replace('cli_', '').split('_')
+            cmds = attr.replace("cli_", "").split("_")
             self._tree[cmds].set_defaults(func=attr)
 
+    def scan_error_handler(self, name):
+        if not issubclass(sys.exc_info()[0], ImportError):
+            raise  # reraise the last exception
+
     def read_package(self, package, require=None):
+        if package in self._scanned_list:
+            return
         # TODO (br) Make 'entrypoints' global
-        scanner = venusian.Scanner(entrypoints=[])
-        scanner.scan(package, categories=['plugnparse'])
-        assert len(scanner.entrypoints) > 0
-        for cmds, arg_factory, fn in scanner.entrypoints:
+        scanner = venusian.Scanner(entrypoints=[], modifiers=[])
+        scanner.scan(
+            package, categories=["plugnparse"], onerror=self.scan_error_handler
+        )
+        self._add_entrypoints(scanner.entrypoints)
+        self._add_modifiers(scanner.modifiers)
+        self._scanned_list.append(package)
+
+    def _add_entrypoints(self, entrypoint_list):
+        assert len(entrypoint_list) > 0, "You MUST supply at least one @entrypoint"
+        for cmds, arg_factory, fn in entrypoint_list:
+            parser = self._tree[cmds]
             _dargs = {self._target: fn}
-            self._tree[cmds].set_defaults(**_dargs)
-            arg_factory(self._tree[cmds])
+            parser.set_defaults(**_dargs)
+            arg_factory(parser)
+
+    def _add_modifiers(self, modifier_list):
+        for cmds, arg_factory in modifier_list:
+            parser = self._tree[cmds]
+            arg_factory(parser)
 
     def _parse_args(self, *args, **dargs):
-        return self._captured_parse_args(*args, **dargs)
+        prefix = self.tree._dest_prefix
+        ns = self._captured_parse_args(*args, **dargs)
+        cmd_dict = {k: v for k, v in vars(ns).items() if k.startswith(prefix)}
+        # ns.cmds = [v for k, v in sorted(cmd_dict.items())]
+        for k in cmd_dict:
+            delattr(ns, k)
+        func = ns.func
+        delattr(ns, "func")
+        return ns, func
 
     def _parse_known_args(self, *args, **dargs):
         return self._captured_parse_known_args(*args, **dargs)

--- a/src/plugnparse/plugins.py
+++ b/src/plugnparse/plugins.py
@@ -1,0 +1,71 @@
+import sys
+import warnings
+import importlib
+
+import venusian
+import pandas as pd
+
+
+class PluginScanner(venusian.Scanner):
+    def __init__(self):
+        self._registry = pd.DataFrame()
+        self._scan_attempts = []
+        self._scan_fails = {}
+
+    def scan_error_handler(self, name):
+        exc = sys.exc_info()
+        self._scan_fails[name] = exc
+        if not issubclass(exc[0], ImportError):
+            raise  # reraise the last exception
+        # self._scan_fails.pop()
+
+    def scan(self, pkg, **dargs):
+        if isinstance(pkg, str):
+            pkg = __import__(pkg)
+        if pkg in self._scan_attempts:
+            return
+        self._scan_attempts.append(pkg)
+        return super().scan(
+            pkg, categories=[self._unique_id], onerror=self.scan_error_handler, **dargs
+        )
+
+    def register_plugin(self, **dargs):
+        self._registry = self._registry.append(pd.Series(dargs), ignore_index=True)
+
+    def make_plugin_decorator(self, **dargs):
+        def _decorator(wrapped):
+            def callback(scanner, name, obj):
+                assert scanner is self
+                scanner.register_plugin(found=obj, **dargs)
+
+            venusian.attach(wrapped, callback, self._unique_id)
+            return wrapped
+
+        return _decorator
+
+    @property
+    def _unique_id(self):
+        return id(self)
+
+    def query(self, query_str, *args, **dargs):
+        if self._scan_fails:
+            warnings.warn(str(self._scan_fails))
+        df = self._registry.query(query_str, *args, **dargs)
+        list_of_dicts = df.to_records("records")
+        return {d["name"]: d["found"] for d in list_of_dicts}
+
+    # def get_first_plugin(self, plugin_type, **dargs):
+    #     filter_df = self._registry.query("plugin_type==@plugin_type")
+    #     assert len(filter_df) > 0
+    #     result = filter_df.apply(lambda row_s: row_s["accepts_fn"](**dargs), axis=1)
+    #     filter_df["accepted"] = result
+    #     filter_df = filter_df.query("accepted==True")
+    #     return filter_df["wrapped_fn"].iloc[0]
+
+    # def get_all_plugins(self, plugin_type, **dargs):
+    #     filter_df = self._registry.query("plugin_type==@plugin_type")
+    #     assert len(filter_df) > 0
+    #     result = filter_df.apply(lambda row_s: row_s["accepts_fn"](**dargs), axis=1)
+    #     filter_df["accepted"] = result
+    #     filter_df = filter_df.query("accepted==True")
+    #     return filter_df["wrapped_fn"].to_list()

--- a/tests/test_plugnparse.py
+++ b/tests/test_plugnparse.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_plugnparse
+----------------------------------
+
+Tests for `plugnparse` module.
+"""
+
+
+import sys
+import unittest
+
+import plugnparse
+
+
+class TestPlugnparse(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_000_something(self):
+        pass
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())


### PR DESCRIPTION
Simple code copy from `f0cal/core`, where the code was being actively maintained. All development should henceforth move to the `f0cal/plugnparse#dev`.